### PR TITLE
Forcing overwrite of the ipywidgets CSS

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -86,8 +86,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
 }
 
 .widget-slider .ui-slider {
-  background: linear-gradient(to right, #fafc32, #f45959, #ef1eaf);
-  border-radius: 4px;
+  background: linear-gradient(to right, #fafc32, #f45959, #ef1eaf) !important;
+  border-radius: 4px !important;
 }
 
 /*Fix cursor of horizontal  scrollbar*/


### PR DESCRIPTION
Trying https://github.com/jupyter/nbconvert/pull/1703 with Voila:

```bash
voila notebooks/basics.ipynb --template=retro --theme=jupyterlab_miami_nights
```

![voila_miami](https://user-images.githubusercontent.com/21197331/149798888-8a08221a-211a-48d7-b2bb-aea7763bece1.png)

We need to force the overwrite of the ipywidgets CSS in order to get the wanted result on the Slider (as shown in the screenshot). This is due to ipywidgets' CSS coming later and overwriting your CSS in the case of Voila.